### PR TITLE
投稿編集機能を実装しました #40

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,21 +14,30 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.build(post_params)
-
+    category_list = params[:post][:category_name].split(',')
     if @post.save
-      if params[:post][:category_names].present?
-        params[:post][:category_names].split(',').each do |category_name|
-          category = Category.find_or_create_by(category_name: category_name.strip.downcase)
-          @post.categories << category
-        end
-      end 
-    redirect_to root_path
+      @post.save_category(category_list)
+      redirect_to root_path(@post), success: 'ポストを作成しました'
     else
       render :new
     end 
   end
 
   def edit
+    @post = current_user.posts.find(params[:id])
+    @category_list = @post.categories.pluck(:category_name).join(',')
+  end
+
+  def update
+    @post = current_user.posts.find(params[:id])
+    category_list = params[:post][:category_name].delete(" ").split(",")
+    if @post.update(post_params)
+      @post.save_category(category_list)
+      redirect_to post_path(@post), success: '投稿を編集しました'
+    else
+      flash.now['danger'] = '編集に失敗しました'
+      render :edit
+    end
   end
 
   private

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -8,4 +8,20 @@ class Post < ApplicationRecord
   attr_accessor :category_names
 
   validates :body, presence: true
+
+  def save_category(sent_categories)
+    current_categories = self.categories.pluck(:category_name) unless self.categories.nil?
+    old_categories = current_categories - sent_categories
+    new_categories = sent_categories - current_categories
+
+    old_categories.each do |old_category_name|
+      self.categories.delete( Category.find_by(category_name: old_category_name))
+    end
+
+    new_categories.each do |new_category_name|
+      new_post_category = Category.find_or_create_by(category_name: new_category_name)
+      self.categories << new_post_category
+    end
+  end
+
 end

--- a/app/models/post_category.rb
+++ b/app/models/post_category.rb
@@ -1,4 +1,7 @@
 class PostCategory < ApplicationRecord
   belongs_to :post
   belongs_to :category
+
+  validates :post_id, presence: true
+  validates :category_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   mount_uploader :avatar, AvatarUploader
 
   has_many :color_palettes, dependent: :destroy
-  has_many :posts
+  has_many :posts, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 255 }
   validates :password, length: { minimum: 3 }, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -15,8 +15,8 @@
     </div>
 
     <div class="form-group">
-      <%= form.label :category_names, "New Category" %>
-      <%= form.text_field :category_names %>
+      <%= form.label :category_name, "New Category" %>
+      <%= form.text_field :category_name , value: @category_list%>
     </div>
   
     <%= form.submit 'Post', class: 'btn btn-primary' %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,2 +1,33 @@
 <h1>Posts#edit</h1>
-<p>Find me in app/views/posts/edit.html.erb</p>
+
+<h1>投稿の編集</h1>
+
+<%= form_with(model: @post, url: post_path(@post), local: true) do |form| %>
+    <div class="form-group">
+      <%= form.label :color_palette_id %>
+      <%= form.collection_select :color_palette_id, current_user.color_palettes, :id, :color_palette_title %>
+    </div>
+  
+    <div class="form-group">
+      <%= form.label :body %>
+      <%= form.text_area :body, rows: 5, class: 'form-control' %>
+    </div>
+  
+    <div class="form-group">
+      <%= form.label :images, "投稿画像" %>
+      <% @post.images.each do |image| %>
+        <div class="image-container">
+          <%= image_tag image.to_s, class: "postimage d-block" %>
+        </div>
+      <% end %>
+      <%= form.file_field :images, multiple: true, class: "form-control" %>
+    </div>
+  
+    <div class="form-group">
+      <%= form.label :category_name, "New Category" %>
+      <%= form.text_field :category_name, value: @category_list %>
+    </div>
+  
+    <%= form.submit 'Edit', class: 'btn btn-primary' %>
+<% end %>
+  

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -48,7 +48,12 @@
     <% end %>
     <% end %>
 </div>  
-
+<% if current_user && current_user.id == @post.user_id %>
+  <div class="container">
+    <%= link_to "編集", edit_post_path(@post), class: "btn btn-primary" %>
+    <%= button_to "削除", post_path(@post), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %>
+  </div>
+<% end %>
 
    
             

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,9 @@ Rails.application.routes.draw do
   resources :color_palettes do
     post 'analyze', on: :collection
   end
-  resources :posts, only: %i[index new create]
+  resources :posts, shallow: true do
+    resources :categories
+  end
  
   
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## チケットへのリンク

#40 

## やったこと

- 投稿編集機能を実装しました

## やらないこと

- 
- 画像編集時に非同期で画像が表示される（MVP後）
- 編集ページのレイアウト修正(MVP後)
- 編集ページをモーダルウィンドウ化(MVP後〜)

## できるようになること（ユーザ目線）

- ユーザーは投稿(カラーパレット/投稿本文/投稿画像/投稿に紐づくカテゴリ)を編集できる

## できなくなること（ユーザ目線）

なし

## 動作確認

- 投稿の編集ページで編集した内容が、post一覧＆post詳細画面で表示されるか確認しました

## その他

