### PR TITLE
ユーザーページの表示方法とルーティングを修正しました

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :set_user, only: %i[ show edit update destroy ]
-
+  before_action :require_admin, only: %i[ index ]
   # GET /users or /users.json
   def index
     @users = User.all
@@ -69,5 +69,12 @@ class UsersController < ApplicationController
     # Only allow a list of trusted parameters through.
     def user_params
       params.require(:user).permit(:name, :email, :password, :password_confirmation, :name)
+    end
+
+    def require_admin
+      unless current_user.admin?
+        flash[:alert] = "You must be an admin to access this page."
+        redirect_to root_path
+      end
     end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,7 +24,7 @@
   </div>
 		</div>
 		<div class="navbar-nav ml-auto action-buttons">
-       <%= link_to 'Profile', profile_path, class: "dropdown-item" %>
+       <%= link_to 'My page', user_path(current_user), class: "dropdown-item" %>
 		</div>
     <div class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-display="static" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,6 +9,7 @@
   <strong>Address:</strong>
   <%= @user.email %>
 </p>
+<%= link_to t('defaults.edit'), edit_profile_path %>
 <h4>Your ColorPalette</h4>
 <div class="container">
   <div class="row">
@@ -20,8 +21,10 @@
             <div class="color-row custom-width" style="height: 15px; background-color:<%= color.closest_palette_color_html_code %>"></div>
           <% end %>
         </div>
-        <%= link_to delete_color_palette_path(color_palette), method: :delete, class: 'delete-color-palette', data: { confirm: 'Are you sure you want to delete this color palette?' } do %>
-          <i class="fa-solid fa-trash-can"></i>
+        <% if current_user == color_palette.user %>
+          <%= link_to delete_color_palette_path(color_palette), method: :delete, class: 'delete-color-palette', data: { confirm: 'Are you sure you want to delete this color palette?' } do %>
+            <i class="fa-solid fa-trash-can"></i>
+          <% end %>
         <% end %>
       </div>
     <% end %>


### PR DESCRIPTION
## チケットへのリンク

* #16 

## やったこと

* ユーザーページのルーティングの修正
* ユーザーページのレイアウト（ユーザー情報編集ページへのリンク設置/ユーザーのカラーパレット削除ボタンの設置）修正
* 作成したユーザー以外カラーパレットが削除できないように修正

## やらないこと

* レイアウト修正(MVP後に順次回収)

## できるようになること（ユーザ目線）

* ユーザーは自身のユーザー情報を編集できる
* ユーザーは自身が作成したカラーパレットを任意で削除できる

## できなくなること（ユーザ目線）

なし

## 動作確認

* 自分以外のユーザーのカラーパレットが削除されないか確認しました

## その他

なし