### PR TITLE
ユーザー新規作成時にパスワードにマスクがかかるように修正しました

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -23,7 +23,7 @@
 
   <div class="field">
     <%= form.label :password %>
-    <%= form.text_field :password %>
+    <%= password_field :password %>
   </div>
   
   <div class="field">

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -23,7 +23,7 @@
 
   <div class="field">
     <%= form.label :password %>
-    <%= password_field :password %>
+    <%= form.password_field :password %>
   </div>
   
   <div class="field">


### PR DESCRIPTION
## チケットへのリンク

* #5 

## やったこと

* ユーザー新規作成時に、パスワードにマスクがかかるように修正しました

## やらないこと

* パスワードにかかっているマスクを、ユーザーは任意で取り外せる機能(MVP後~本リリースまでに改修)

## できるようになること（ユーザ目線）

* 新規ユーザー作成時にパスワード入力する際、パスワードにマスクが入るので安全に新規登録できる

## できなくなること（ユーザ目線）

* ユーザーはパスワード入力欄を直接見ることができない

## 動作確認

* ローカル環境でアプリケーションに接続
* 新規ユーザー作成ページに行き、パスワードにマスクがかかっていることを確認

## その他

なし