### PR TITLE
ログイン前のヘッダーを修正しました

### DIFF
--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -8,7 +8,6 @@
 		<div class="navbar-nav">
 			<a href="/" class="nav-item nav-link">Home</a>
 			<a href="" class="nav-item nav-link">About</a>			
-			<a href="/color_palettes/new" class="nav-item nav-link">Analyze Color</a>
 		</div>
 		<form class="navbar-form form-inline">
     <div class="input-group search-box">


### PR DESCRIPTION
## チケットへのリンク

* #44 

## やったこと

* ログイン前のユーザーがカラー分析できないように、ログイン前のヘッダーを修正しました。

## やらないこと

* ログイン前のユーザーでも、カラー分析できるようにする（カラーパレットを作成しようとすると、ユーザー登録ページに遷移して、ログイン後にカラーパレットを作成できる）→本リリース後に実装予定

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

* ログイン前のユーザーはカラー分析ができない

## 動作確認

動作確認にあたって、以下の手順で確認しました

* ローカルでアプリケーションを起動し、未ログインの状態でアクセスしてヘッダーにanalyze colorがないことを確認

## その他

なし