### PR TITLE
画像が表示されなくなるエラーを修正しました

### DIFF
--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -41,7 +41,14 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
-  # def filename
-  #   "something.jpg" if original_filename
-  # end
+  def filename
+    "#{secure_token}.#{file.extension}" if original_filename.present?
+  end
+
+  private
+
+  def secure_token
+    var = :"@#{mounted_as}_secure_token"
+    model.instance_variable_get(var) or model.instance_variable_set(var, SecureRandom.uuid)
+  end
 end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,6 @@
 <head>
 <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
-<link rel="stylesheet" href="path/to/custom.css">
+<link rel="stylesheet" href="path/to/custom.scss">
 <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.3/dist/umd/popper.min.js"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,6 @@ require "rails"
 require "active_model/railtie"
 require "active_job/railtie"
 require "active_record/railtie"
-require "active_storage/engine"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 require "action_mailbox/engine"
@@ -13,6 +12,9 @@ require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
+require 'carrierwave'
+require 'carrierwave/orm/activerecord'
+
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -61,6 +61,8 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  config.autoload_paths += %W({config.root}/app/uploaders)
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 

--- a/db/migrate/20230416034954_remove_active_storage.rb
+++ b/db/migrate/20230416034954_remove_active_storage.rb
@@ -1,0 +1,7 @@
+class RemoveActiveStorage < ActiveRecord::Migration[6.1]
+  def change
+    drop_table :active_storage_attachments
+    drop_table :active_storage_blobs, force: :cascade
+    drop_table :active_storage_variant_records
+  end  
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,38 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_09_070025) do
+ActiveRecord::Schema.define(version: 2023_04_16_034954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
-  end
-
-  create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.string "service_name", null: false
-    t.bigint "byte_size", null: false
-    t.string "checksum", null: false
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
-  end
-
-  create_table "active_storage_variant_records", force: :cascade do |t|
-    t.bigint "blob_id", null: false
-    t.string "variation_digest", null: false
-    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
-  end
 
   create_table "categories", force: :cascade do |t|
     t.string "category_name"
@@ -109,8 +81,6 @@ ActiveRecord::Schema.define(version: 2023_04_09_070025) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "color_palette_colors", "color_palettes"
   add_foreign_key "color_palette_colors", "colors"
   add_foreign_key "color_palettes", "users"


### PR DESCRIPTION
## チケットへのリンク

* #12 , #13 

## やったこと

* 投稿一覧及び投稿詳細画面で、投稿した画像が表示されないエラーが起きたためactive_storageテーブルの削除（carrierwaveと競合してしまっていたため、起きた可能性あり）や、image_uploaderファイル設定の修正を行いました

## やらないこと

なし

## できるようになること（ユーザ目線）

* ユーザーは投稿画像を閲覧できる

## できなくなること（ユーザ目線）

なし

## 動作確認
動作確認するにあたって、以下の手順で確認しました

* ローカルでアプリケーションに接続後、　ユーザー新規登録
* 登録後カラーパレットを作成して、投稿を新規作成
* 新規作成時に画像を添付し、投稿一覧および投稿詳細に画像が正しく表示されているか確認

## その他

* migarationファイルを修正した為、データリセットしました