### PR TITLE
投稿者の名前が表示されるように修正しました

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -15,9 +15,9 @@
                  <%= image_tag post.images.first.to_s, class: "postimage" %>
                 <% end %>
               <% end %>  
-            </div>
+            </div> 
         </div>    
-    </div>        
+    </div>       
   <% end %>
 </div>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,7 +7,7 @@
 </head>
 
 <h1>Posts</h1>
-<p>Posted by: <%= @post.user.name %></p>
+<p>Posted by: <%= link_to @post.user.name, user_path(@post.user) %>
 
 <div class="container-show">
     <div class="row">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,9 +6,8 @@
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 </head>
 
-<h1>Posts#show</h1>
-<p>Find me in app/views/posts/show.html.erb</p>
-
+<h1>Posts</h1>
+<p>Posted by: <%= @post.user.name %></p>
 
 <div class="container-show">
     <div class="row">


### PR DESCRIPTION
## チケットへのリンク

* #13 

## やったこと

* 投稿詳細画面で、その投稿のユーザー名を確認できる
* ユーザー名をクリックすると、そのユーザーのマイページに遷移する

## やらないこと

* レイアウト修正(リリースまでに順次改修)

## できるようになること（ユーザ目線）

* ユーザーはその投稿のユーザーを確認できる
* ユーザー名をクリックすることで、そのユーザーのマイページを閲覧できる

## できなくなること（ユーザ目線）

なし

## 動作確認

動作確認するにあたって、以下の手順で確認しました

* ローカルでアプリケーションに接続して、新規でユーザーを複数登録
* user1でログイン中にuser2の投稿詳細に遷移して、ユーザー名が正しく表示されているか確認
* ユーザー名をクリックして、正しいユーザーページに遷移しているか確認(該当ユーザー以外で削除ボタンが表示されていないか確認)

## その他

なし