### PR TITLE
password confirmationにマスクをつけました

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -28,7 +28,7 @@
   
   <div class="field">
     <%= form.label :password_confirmation %>
-    <%= form.text_field :password_confirmation %>
+    <%= form.password_field :password_confirmation %>
   </div>
 
   <div class="actions">


### PR DESCRIPTION
## チケットへのリンク

* #5 

## やったこと

* password confirmationがマスクがかかるように修正しました

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 新規ユーザー登録時に、password confirmationにマスクが掛かっていることで安全にユーザー作成できる

## できなくなること（ユーザ目線）

なし

## 動作確認
動作確認にあたり、以下の手順で確認しました

* ローカルでアプリケーションにアクセスし、新規ユーザー作成
* ユーザー作成のpassword confirmationにマスクが掛かっていることを確認

## その他

なし