### PR TITLE
カラーパレット作成時の複数色選択時のフォーマットを編集しました

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -135,3 +135,10 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 .form-inline .form-control{
 	width: 500px ;
 }
+
+.selected-color {
+	border: 2px solid #000;
+	outline: 2px solid rgba(255, 255, 255, 0.5);
+  	outline-offset: -4px;
+}
+  

--- a/app/views/color_palettes/analyze.html.erb
+++ b/app/views/color_palettes/analyze.html.erb
@@ -1,52 +1,37 @@
 <div class="container">
   <div class="row">
-    <div class="col-md-6">
-      <% @extracted_data = @result['result']['colors']['image_colors'].map { |image_color| { closest_palette_color: image_color["closest_palette_color"], closest_palette_color_html_code: image_color["closest_palette_color_html_code"] } } %>
-      <% @extracted_data.each do |data| %>
-        <div class="w-25 p-3 mb-3" style="height: 50px; background-color: <%= data[:closest_palette_color_html_code] %>"></div>
-        <p><%= data[:closest_palette_color] %></p>
-      <% end %>
+  <div class="col-md-6">
+  <% @extracted_data = @result['result']['colors']['image_colors'].map { |image_color| { closest_palette_color: image_color["closest_palette_color"], closest_palette_color_html_code: image_color["closest_palette_color_html_code"] } } %>
+  <%= form_with model: @color_palette, url: "/color_palettes", method: "post", remote: true do |form| %>
+    <div class="field">
+      <%= form.label :color_palette_title %>
+      <%= form.text_field :color_palette_title %>
     </div>
-    <div class="col-md-6">
-      <img src="data:image/png;base64,<%= @image_data %>" />
-      <%= form_with model: @color_palette, url: "/color_palettes", method: "post", remote: true do |form| %>
-        <div class="field">
-          <%= form.label :color_palette_title %>
-          <%= form.text_field :color_palette_title %>
+    <% @extracted_data.each do |data| %>
+      <div class="d-flex align-items-center mb-3">
+        <div class="color-box" style="width: 50px; height: 50px; background-color: <%= data[:closest_palette_color_html_code] %>">
+          <input type="checkbox" class="color-checkbox" value="<%= data[:closest_palette_color] %>|<%= data[:closest_palette_color_html_code] %>" name="color_palette[colors][]" style="display: none;">
         </div>
-        
-        <div class="field">
-          <%= form.label :colors %>
-          <select id="selected_colors" name="color_palette[colors][]" multiple> 
-            <% @extracted_data.each do  |data|  %>
-              <option value="<%= data[:closest_palette_color] %>|<%= data[:closest_palette_color_html_code] %>">
-                <%= data[:closest_palette_color] %>
-              </option>  
-            <% end %>  
-          </select>  
-        </div>
+        <p class="ml-3"><%= data[:closest_palette_color] %></p>
+      </div>
+    <% end %>
+    <%= form.submit "Create color palette" %>
+  <% end %>
+</div>
+<div class="col-md-6">
+  <img src="data:image/png;base64,<%= @image_data %>" />
+</div>
 
-        <%= form.submit "Create color palette" %>
-      <% end %>
-    </div>
   </div>
 </div>
 
 
 <script>
 $(document).ready(function() {
-  // フォームの送信ボタンを無効にする
-  $('form').find('input[type="submit"]').prop('disabled', true);
-
-  // タイトルとカラーが選択された場合にのみボタンを有効にする
-  $('form').on('input', function() {
-    var title = $('#color_palette_title').val();
-    var colors = $('#selected_colors').val();
-    if (title !== '' && colors !== null && colors.length > 0) {
-      $('form').find('input[type="submit"]').prop('disabled', false);
-    } else {
-      $('form').find('input[type="submit"]').prop('disabled', true);
-    }
+  $('.color-box').click(function() {
+    var $checkbox = $(this).find('.color-checkbox');
+    $checkbox.prop('checked', !$checkbox.prop('checked'));
+    $(this).toggleClass('selected-color');
   });
 });
 </script>

--- a/lib/image_analyzer.rb
+++ b/lib/image_analyzer.rb
@@ -9,7 +9,7 @@ module ImageAnalyzer
         begin
           response = RestClient.post "https://api.imagga.com/v2/colors?overall_count=10&extract_object_colors=0", { :image => File.new(image_path, 'rb') }, { :Authorization => "Basic YWNjXzA1NjE5ZTllYzkxNzlkMDo3ZjY2MGMwYzBhNzk4YWY4MzgwNTc2ZTAwZDA1MjZiZg==" }
         rescue RestClient::Exception => e
-          return { error: "API request failed" }
+          return { error: "エラーが発生しました。もう一度やり直してください。" }
         end
 
         result = JSON.parse(response)


### PR DESCRIPTION
## チケットへのリンク

* #23 

## やったこと

* カラーパレット作成時に色を複数選択する方法を、selected box内の色の名前から選択する方法から、色(color-box)を直接選択する形式に変更しました。

## やらないこと

*レイアウト修正（リリースまでに改修）

## できるようになること（ユーザ目線）

* ユーザーは、カラーパレット作成時に直接色選択できるので、作成方法がよりわかりやすい

## できなくなること（ユーザ目線）

* なし

## 動作確認
以下の動作を行い、動作確認しました

* ローカルでアプリケーションに接続
* ユーザーログインして画像からカラーパレットを作成
* 作成時にカラーを直接選択できることを確認
* 選択したカラーからカラーパレットが作成できることを確認。

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）