### PR TITLE
カラーパレットコントローラのcreateアクションを修正しました

### DIFF
--- a/app/controllers/color_palettes_controller.rb
+++ b/app/controllers/color_palettes_controller.rb
@@ -24,21 +24,25 @@ require 'image_analyzer'
       if @color_palette.save
         selected_colors = params[:color_palette][:colors]
         colors = []
-        selected_colors.each do |selected_color|
-          closest_palette_color, closest_palette_color_html_code = selected_color.split('|')
-          color = Color.find_or_create_by(closest_palette_color: closest_palette_color, closest_palette_color_html_code: closest_palette_color_html_code)
-          colors << color
+    
+        # トランザクション追加
+        ActiveRecord::Base.transaction do
+          colors = selected_colors.map do |selected_color|
+            closest_palette_color, closest_palette_color_html_code = selected_color.split('|')
+            color = Color.find_or_create_by(closest_palette_color: closest_palette_color, closest_palette_color_html_code: closest_palette_color_html_code)
+          end
+    
+          colors.each do |color|
+            ColorPaletteColor.create!(color_palette: @color_palette, color: color)
+          end
         end
-      
-        colors.each do |color|
-          ColorPaletteColor.create(color_palette: @color_palette, color: color)
-        end
+    
         # リダイレクトする
         redirect_to user_url(current_user)
       else
         render :new
       end
-    end
+    end    
 
     def delete
       @color_palette = ColorPalette.find(params[:id])


### PR DESCRIPTION
## チケットへのリンク

* #23 

## やったこと

* カラーパレットの作成時のcreate Actionで、transactionで登録データの整合性を確保するためにActiveRecord::Baseコードを用いて修正しました
* eachメソッドからmapメソッドに変更

## やらないこと

なし

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認
以下の手順を行い、動作確認しました

* ローカルでアプリケーションに接続
* ユーザーログインし、カラーパレットを作成
* ユーザーページで、先ほど作成したカラーパレットが正常に作成されていることを確認

## その他

なし