### PR TITLE
画像分析時のアップロードページを修正しました

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -150,8 +150,37 @@ $fa-font-path: '@fortawesome/fontawesome-free/webfonts';
 	justify-content: center;
 }
   
-  .custom-modal .modal-content {
+.custom-modal .modal-content {
 	height: 100%;
 	overflow-y: auto;
 }
   
+.upload-drop-zone {
+	height: 200px;
+	border: 2px dashed #999;
+	line-height: 200px;
+	text-align: center;
+	font-size: 20px;
+	color: #999;
+}
+  
+.upload-drop-zone.drop {
+	color: #222;
+	border-color: #222;
+}
+
+.preview{
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+  
+
+.analyze-button {
+	display: block;
+	margin-right: 80px;
+	margin-top: 15px;
+	margin-left: auto;
+}

--- a/app/assets/stylesheets/color_palettes.scss
+++ b/app/assets/stylesheets/color_palettes.scss
@@ -1,3 +1,14 @@
 // Place all the styles related to the ColorPalettes controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+#image-preview {
+    width: 220px; /* 画像の幅を500pxに設定 */
+    height: auto; /* 高さは幅に合わせて自動的に調整 */
+}
+
+#image_path {
+    width: 400px;
+    height: auto;
+}
+  
+  

--- a/app/controllers/color_palettes_controller.rb
+++ b/app/controllers/color_palettes_controller.rb
@@ -6,9 +6,23 @@ class ColorPalettesController < ApplicationController
   require 'image_analyzer'
 
   def analyze
+    if params[:image_path].blank? 
+      flash[:alert] = "画像がアップロードされていません"
+      redirect_to new_color_palette_path
+      return
+    end
+    
     image_path = params[:image_path].path
+    image_extension = File.extname(image_path)
+  
+    unless [".jpg", ".png", ".jpeg", ".gif"].include?(image_extension.downcase)
+      flash[:alert] = "無効な画像拡張子です"
+      redirect_to new_color_palette_path
+      return
+    end
+  
     result_data = ImageAnalyzer.analyze(image_path)
-
+  
     if result_data[:error]
       flash[:alert] = result_data[:error]
       redirect_to new_color_palette_path
@@ -17,6 +31,7 @@ class ColorPalettesController < ApplicationController
       @image_data = result_data[:image_data]
     end
   end
+  
 
   def create
     # カラーパレットを作成する

--- a/app/javascript/packs/image_upload.js
+++ b/app/javascript/packs/image_upload.js
@@ -1,0 +1,46 @@
+let dropArea = document.getElementById('drop-area');
+let fileInput = document.getElementById('file-input');
+
+// ドラッグ&ドロップ時のイベントハンドラを設定
+['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
+  dropArea.addEventListener(eventName, preventDefaults, false);
+});
+
+function preventDefaults(e) {
+  e.preventDefault();
+  e.stopPropagation();
+}
+
+// ドロップ時のイベントハンドラを設定
+dropArea.addEventListener('drop', handleDrop, false);
+
+function handleDrop(e) {
+  let files = e.dataTransfer.files;
+  fileInput.files = files;
+  handleFiles(files);
+}
+
+// クリック時にファイル選択ダイアログを開く
+dropArea.addEventListener('click', function() {
+  fileInput.click();
+});
+
+// ファイル選択時にプレビューを表示
+fileInput.addEventListener('change', function() {
+  handleFiles(this.files);
+});
+
+function handleFiles(files) {
+  let preview = document.getElementById('image-preview');
+  let file = files[0];
+  let reader = new FileReader();
+
+  reader.addEventListener("load", function () {
+    preview.src = reader.result;
+    preview.style.display = "block";
+  }, false);
+
+  if (file) {
+    reader.readAsDataURL(file);
+  }
+}

--- a/app/views/color_palettes/new.html.erb
+++ b/app/views/color_palettes/new.html.erb
@@ -3,9 +3,23 @@
     <%= flash[:alert] %>
   </div>
 <% end %>
+
 <%= form_with url: "/color_palettes/analyze", local: true, method: :post, html: { multipart: true } do |form| %>
-  <%= form.file_field :image_path %>
-  <%= form.submit "Analyze" %>
+  <div id="drop-area" style="width: 100%; height: 200px; border: 2px dashed rgb(218, 218, 218); border-radius: 20px; text-align: center;">
+    <p>ドラッグアンドドロップまたはクリックして、画像を追加する</p>
+  <input id="file-input" type="file" name="image_path" style="display: none;" />
+</div>
+
+  <%= form.submit "Analyze", class: "analyze-button" %>
 <% end %>
 
 
+<div class='preview'>
+  <div>
+    <p>Preview</p>
+  <div>  
+  <img id="image-preview" src="#" alt="your image" style="display:none;" />
+</div>
+
+
+<%= javascript_pack_tag 'image_upload' %>


### PR DESCRIPTION
## チケットへのリンク

* #22 

## やったこと

* 画像分析時の画像アップロードフォームにドラックアンドドロップor画像ファイルを選択できるフォームを設定しました
* 画像アップロード時に画像確認できるようにプレビューエリアを設定しました
* 画像がアップされていない場合&無効な拡張子のファイルがアップロードされた場合はエラー文が表示されるように設定しました
## やらないこと

なし

## できるようになること（ユーザ目線）

* ユーザーは画像分析する前にどんな画像がアップロードされるかpreviewで確認できる
* ドラックアンドドロップでも画像アップロードができるようになる
* 万が一画像なしor無効な拡張子でanalyzeボタンを押してしまってもエラー警告が出るようになる

## できなくなること（ユーザ目線）

なし

## 動作確認
以下の手順を行い、動作確認しました

* ローカル環境でアプリケーションに接続
* 画像分析フォームで画像アップロードフォームの変更が適応されていることを確認
* 画像previewが表示されることを確認
* ドラックアンドドロップでも画像がアップロードされることを確認
* 画像なしでanalyzeしてしまった場合にエラー文が出てアップロードページに遷移することを確認

## その他

なし