### PR TITLE
Feature/recommend posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -19,4 +19,17 @@ class Post < ApplicationRecord
       categories << category unless categories.include?(category)
     end
   end
+
+  def selected_colors
+    self.color_palette.color_palette_colors.sample(2).map(&:color)
+  end
+
+  
+  def recommended_posts
+    Post.joins(color_palette: :color_palette_colors)
+        .where(color_palette_colors: { color_id: self.selected_colors.map(&:id) })
+        .where.not(id: self.id)
+        .distinct
+  end
+  
 end

--- a/app/views/posts/_show.html.erb
+++ b/app/views/posts/_show.html.erb
@@ -70,6 +70,7 @@
   </div>
 <% end %> 
 
+<h4>Recommend posts</h4>
 <div class="container-userpage">
   <% @post.recommended_posts.each do |post| %>
     <div class="row1">

--- a/app/views/posts/_show.html.erb
+++ b/app/views/posts/_show.html.erb
@@ -69,3 +69,28 @@
     <%= button_to "削除", post_path(@post), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-danger" %>
   </div>
 <% end %> 
+
+<div class="container-userpage">
+  <% @post.recommended_posts.each do |post| %>
+    <div class="row1">
+      <div class="col-sm-2">
+        <div class="row"> 
+            <div class="color-palette">
+                <% post.color_palette.colors.each do |color| %>
+                    <div class="color-row" style="width: 28px; background-color:<%= color.closest_palette_color_html_code %>"></div>
+                <% end %>
+            </div>
+        </div>
+        <div class="row">      
+            <div class="image-container">
+              <%= link_to post_path(post), class: 'btn', remote: true, data: { toggle: 'modal', target: '#postModal' } do %>
+                  <% if post.images.any? %>
+                    <%= image_tag post.images.first.to_s, class: "postimage" %>
+                  <% end %>
+              <% end %>  
+            </div>
+        </div>    
+      </div>  
+    </div>                
+  <% end %>
+</div>  


### PR DESCRIPTION
## チケットへのリンク

* #134 

## やったこと

* 投稿詳細画面で、その投稿のカラーパレットに関連する他の投稿が表示されるようにしました
* 投稿のカラーパレットから無作為に2色の色を選択するメソッドを追加
* その二色を含むカラーパレットが存在する投稿を検索するメソッドを追加

## やらないこと

* レイアウト修正(新規投稿のフォーマット修正完了後にこちらも修正予定)

## できるようになること（ユーザ目線）

* 特定の投稿のカラーパレットに関連した他の投稿を閲覧することができる

## できなくなること（ユーザ目線）

なし

## 動作確認
以下の手順で動作確認しました

* ローカル環境でアプリケーションに接続
* 投稿詳細画面(modal window)に遷移し、その投稿のカラーパレットに関連したrelated postsが複数表示されていることを確認



## その他

なし